### PR TITLE
Update create-payment-method.response.ts

### DIFF
--- a/libs/stripe/package.json
+++ b/libs/stripe/package.json
@@ -1,6 +1,6 @@
-{
+z{
   "name": "@valor/nestjs-stripe",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "type": "commonjs",
   "private": false,
   "author": "opavlovskyi-valor-software",

--- a/libs/stripe/package.json
+++ b/libs/stripe/package.json
@@ -1,4 +1,4 @@
-z{
+{
   "name": "@valor/nestjs-stripe",
   "version": "0.0.24",
   "type": "commonjs",

--- a/libs/stripe/src/lib/dto/create-payment-method.dto.ts
+++ b/libs/stripe/src/lib/dto/create-payment-method.dto.ts
@@ -222,7 +222,7 @@ export class FpxDto {
 
   @ApiProperty({
     description: 'The customer\'s bank.',
-    enum: [FpxBanks]
+    enum: FpxBanks
   })
   bank: Stripe.PaymentMethodCreateParams.Fpx.Bank;
 }
@@ -432,7 +432,7 @@ export class CreatePaymentMethodDto {
 
   @ApiPropertyOptional({
     description: 'The type of the PaymentMethod. An additional hash is included on the PaymentMethod with a name matching this value. It contains additional information specific to the PaymentMethod type.',
-    enum: [PaymentMethodTypes],
+    enum: PaymentMethodTypes,
     default: 'card'
   })
   type?: Stripe.PaymentMethodCreateParams.Type;

--- a/libs/stripe/src/lib/dto/create-payment-method.response.ts
+++ b/libs/stripe/src/lib/dto/create-payment-method.response.ts
@@ -1,5 +1,7 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
 import { BaseResponse } from './base.response';
 
 export class CreatePaymentMethodResponse extends BaseResponse {
+  @ApiPropertyOptional()
   paymentMethodId?: string;
 }

--- a/libs/stripe/src/lib/dto/create-payment-method.response.ts
+++ b/libs/stripe/src/lib/dto/create-payment-method.response.ts
@@ -5,4 +5,3 @@ export class CreatePaymentMethodResponse extends BaseResponse {
   @ApiPropertyOptional()
   paymentMethodId?: string;
 }
-

--- a/libs/stripe/src/lib/dto/create-payment-method.response.ts
+++ b/libs/stripe/src/lib/dto/create-payment-method.response.ts
@@ -5,3 +5,4 @@ export class CreatePaymentMethodResponse extends BaseResponse {
   @ApiPropertyOptional()
   paymentMethodId?: string;
 }
+

--- a/libs/stripe/src/lib/dto/stripe/invoice-line-item.dto.ts
+++ b/libs/stripe/src/lib/dto/stripe/invoice-line-item.dto.ts
@@ -85,7 +85,7 @@ export class InvoiceLineItemDto extends BaseDto {
   })
   taxAmounts?: Array<TaxAmountDto>;
 
-  @ApiProperty({ isArray: true })
+  @ApiProperty({ isArray: true, type: Object })
   taxRates?: Array<Stripe.TaxRate>;
 
   @ApiProperty({

--- a/libs/stripe/src/lib/dto/stripe/invoice.dto.ts
+++ b/libs/stripe/src/lib/dto/stripe/invoice.dto.ts
@@ -274,7 +274,7 @@ export class InvoiceDto extends BaseDto {
   automaticTax: AutomaticTaxDto;
 
   @ApiProperty({
-    enum: [BillingReasons]
+    enum: BillingReasons
   })
   billingReason: Stripe.Invoice.BillingReason | null;
 

--- a/libs/stripe/src/lib/dto/stripe/plan.dto.ts
+++ b/libs/stripe/src/lib/dto/stripe/plan.dto.ts
@@ -32,7 +32,7 @@ export class PlanDto extends BaseDto {
   @ApiProperty()
   product: string | ProductDto | null;
 
-  @ApiProperty({ isArray: true })
+  @ApiProperty({ isArray: true, type: Object })
   tiers?: Array<Stripe.Plan.Tier>;
 
   @ApiProperty({ enum: ['graduated', 'volume']})


### PR DESCRIPTION
This fixes some inconsistencies into untyped arrays and missing fields.

All arrays must have an `items` key defined, `type: Object` siply adds a `{ type: 'object' }` into the resulting schema allowing it to be parsed by valid openapi tools